### PR TITLE
Add default reply for Schumi if it meets unknown user behavior.

### DIFF
--- a/app/common_reply.py
+++ b/app/common_reply.py
@@ -92,6 +92,11 @@ pattern_mapping = [
         'multi_type_output': True
     },
     {
+        'cmd': '朽咪',
+        'type': search,
+        'function': unknown_schumi_behavior,
+    },
+    {
         'cmd': choice_pattern,
         'type': 'search',
         'function': choice,

--- a/app/common_reply.py
+++ b/app/common_reply.py
@@ -94,7 +94,7 @@ pattern_mapping = [
     {
         'cmd': '朽咪',
         'type': search,
-        'function': unknown_schumi_behavior,
+        'function': unknown_schumi_behavior
     },
     {
         'cmd': choice_pattern,

--- a/app/direct_reply.py
+++ b/app/direct_reply.py
@@ -63,3 +63,6 @@ def gurulingpo():
  `･+｡*･+ ﾟ
     '''
     return s
+
+def unknown_schumi_behavior():
+    return '朽咪對於你想做的事情感到驚恐 他慌張的跑到電話旁邊準備打給警察局'


### PR DESCRIPTION
Hi Leafwind,

Right now Schumi has two known behavior, "摸朽咪" and "找朽咪".

I think there is a need for Schumi to have default reply if it meets some behavior it doesn't understand. Like "餵朽咪", "咬朽咪", "親朽咪" and so on.

In this PR I wrote a default, direct reply for it. Maybe in the future it can be a dice reply?

Thanks!